### PR TITLE
[Editorial] Modernize spelling: "boy friend" -> "boyfriend"

### DIFF
--- a/src/epub/text/chapter-10.xhtml
+++ b/src/epub/text/chapter-10.xhtml
@@ -26,7 +26,7 @@
 			<p>We rode into town rapidly.</p>
 			<p>“Is Bush dead?” she asked as she twisted the car into Broadway.</p>
 			<p>“Decidedly. When they turned him over the point of the knife was sticking out in front.”</p>
-			<p>“He ought to have known better than to double-cross them. Let’s get something to eat. I’m almost eleven-hundred ahead on the night’s doings, so if the boy friend doesn’t like it, it’s just too bad. How’d you come out?”</p>
+			<p>“He ought to have known better than to double-cross them. Let’s get something to eat. I’m almost eleven-hundred ahead on the night’s doings, so if the boyfriend doesn’t like it, it’s just too bad. How’d you come out?”</p>
 			<p>“Didn’t bet. So your Max doesn’t like it?”</p>
 			<p>“Didn’t bet?” she cried. “What kind of an ass are you? Whoever heard of anybody not betting when they had a thing like that sewed up?”</p>
 			<p>“I wasn’t sure it was sewed up. So Max didn’t like the way things turned out?”</p>

--- a/src/epub/text/chapter-20.xhtml
+++ b/src/epub/text/chapter-20.xhtml
@@ -73,7 +73,7 @@
 			<p>“Will you stop talking about killing!”</p>
 			<p>“Young Albury once told me Bill Quint had threatened to kill you,” I said.</p>
 			<p>“Stop it.”</p>
-			<p>“You seem to have a gift for stirring up murderous notions in your boy friends. There’s Albury waiting trial for killing Willsson. There’s Whisper who’s got you shivering in corners. Even I haven’t escaped your influence. Look at the way I’ve turned. And I’ve always had a private notion that Dan Rolff’s going to have a try at you some day.”</p>
+			<p>“You seem to have a gift for stirring up murderous notions in your boyfriends. There’s Albury waiting trial for killing Willsson. There’s Whisper who’s got you shivering in corners. Even I haven’t escaped your influence. Look at the way I’ve turned. And I’ve always had a private notion that Dan Rolff’s going to have a try at you some day.”</p>
 			<p>“Dan! You’re crazy. Why, I⁠—”</p>
 			<p>“Yeah. He was a lunger and down and out, and you took him in. You gave him a home and all the laudanum he wants. You use him for errand boy, you slap his face in front of me, and slap him around in front of others. He’s in love with you. One of these mornings you’re going to wake up and find he’s whittled your neck away.”</p>
 			<p>She shivered, got up and laughed.</p>


### PR DESCRIPTION
As a father of a daughter, there's now a very significant difference between talking about her "boy friends" and her "boyfriends" -- even if both meanings would have used "boy friends" in 1929.