### PR TITLE
[Editorial] Fix likely typo

### DIFF
--- a/src/epub/text/chapter-18.xhtml
+++ b/src/epub/text/chapter-18.xhtml
@@ -24,7 +24,7 @@
 			<p>“What’s doing?”</p>
 			<p>“Spot two. Out three-thirty, office to Willsson’s. Mickey. Five. Home. Busy. Kept plant. Off three, seven. Nothing yet.”</p>
 			<p>That was supposed to inform me that he had picked up Lew Yard at two the previous afternoon; had shadowed him to Willsson’s at three-thirty, where Mickey had tailed Pete; had followed Yard away at five, to his residence; had seen people going in and out of the house, but had not shadowed any of them; had watched the house until three this morning, and had returned to the job at seven; and since then had seen nobody go in or out.</p>
-			<p>“You’ll have to drop this and take a plant on Willsson’s,” I said. “I hear Whisper Thaler’s holing-up there, and I’d like an eye kept on him till I make up my mind whether to turn him up for Noonan or not.”</p>
+			<p>“You’ll have to drop this and take a plant on Willsson’s,” I said. “I hear Whisper Thaler’s holing up there, and I’d like an eye kept on him till I make up my mind whether to turn him up for Noonan or not.”</p>
 			<p>Dick nodded and started the engine grinding. I got out and returned to the hotel.</p>
 			<p>There was a telegram from the Old Man:</p>
 			<blockquote class="telegram" epub:type="z3998:letter">


### PR DESCRIPTION
"holing-up" seems more like a noun; "holing up" is a verb.